### PR TITLE
Ensure commit has is clean git status

### DIFF
--- a/cmake/git_revision.cmake
+++ b/cmake/git_revision.cmake
@@ -9,6 +9,15 @@ if(GIT_FOUND)
     if(NOT ${GIT_REVISION} STREQUAL "")
         string(STRIP ${GIT_REVISION} GIT_REVISION)
     endif()
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} status -s
+        OUTPUT_VARIABLE GIT_CHANGES
+        ERROR_QUIET
+        )
+    if(NOT ${GIT_CHANGES} STREQUAL "")
+        string(APPEND GIT_REVISION "-:UNCOMMITTED CHANGES")
+        message("There are uncommited changes adjust .gitignore or commit: ${GIT_CHANGES}")
+    endif()
     message(STATUS "Current git revision is ${GIT_REVISION}")
 else()
     set(GIT_REVISION "unknown")


### PR DESCRIPTION
Previously the commit hash was added regardless if there are uncommitted changes or not. This meant that a commit hash in a build is not strictly bound to the file-state. Now the script also checks if there are uncommitted changes and marks the revision as such. This is still not perfect as the developer can use a poorly configured .gitignore to get changes into the same hash. However, it proves as a guard against carelessness.